### PR TITLE
Add methods to find group(s) in regex match(es) in file

### DIFF
--- a/Cake.FileHelpers.Tests/FileHelperTests.cs
+++ b/Cake.FileHelpers.Tests/FileHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Text.RegularExpressions;
 using Cake.Xamarin.Tests.Fakes;
 using Cake.Core.IO;
 
@@ -121,6 +122,47 @@ namespace Cake.FileHelpers.Tests
             }
         }
 
+        public const string GROUPS_FILE = "./testdata/Groups.txt";
+        public const string GROUPS_FILE_CONTENT = "Hello World! This is A quick Test to Capture multiple Groups.";
+        public const string GROUPS_PATTERN = "([A-Z])(\\w+)";
+
+        [Test]
+        public void FindRegexMatchesGroupsInFile ()
+        {
+            context.CakeContext.FileWriteText (GROUPS_FILE, GROUPS_FILE_CONTENT);
+
+            var matchesGroups = context.CakeContext.FindRegexMatchesGroupsInFile (GROUPS_FILE, GROUPS_PATTERN, RegexOptions.None);
+
+            Assert.IsNotNull (matchesGroups);
+            Assert.AreEqual (matchesGroups.Count, 6);
+
+            foreach (var g in matchesGroups)
+                Assert.AreEqual (g.Count, 3);
+        }
+
+        [Test]
+        public void FindRegexMatchGroupsInFile()
+        {
+            context.CakeContext.FileWriteText (GROUPS_FILE, GROUPS_FILE_CONTENT);
+
+            var matchGroups = context.CakeContext.FindRegexMatchGroupsInFile (GROUPS_FILE, GROUPS_PATTERN, RegexOptions.None);
+
+            Assert.IsNotNull (matchGroups);
+            Assert.AreEqual (matchGroups.Count, 3);
+        }
+
+        [Test]
+        public void FindRegexMatchGroupInFile ()
+        {
+            context.CakeContext.FileWriteText (GROUPS_FILE, GROUPS_FILE_CONTENT);
+
+            var matchGroup = context.CakeContext.FindRegexMatchGroupInFile (GROUPS_FILE, GROUPS_PATTERN, 2, RegexOptions.None);
+            var invalidMatchGroup = context.CakeContext.FindRegexMatchGroupInFile (GROUPS_FILE, GROUPS_PATTERN, 8, RegexOptions.None);
+
+            Assert.IsNotNull (matchGroup);
+            Assert.IsNull (invalidMatchGroup);
+            Assert.AreEqual (matchGroup.Value, "ello");
+        }
 
         public const string PATTERN_FILE_BASE_VALUE = "The {0} makes great software.\nThis is not a surprise.";
 

--- a/Cake.FileHelpers/FileHelpers.cs
+++ b/Cake.FileHelpers/FileHelpers.cs
@@ -292,6 +292,70 @@ namespace Cake.FileHelpers
 
             return null;
         }
+
+        /// <summary>
+        /// Finds regex matches in a file and returns all match groups.
+        /// </summary>
+        /// <returns>The matches with their groups.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file.</param>
+        /// <param name="rxFindPattern">The regex pattern to search for.</param>
+        /// <param name="rxOptions">The regex options.</param>
+        [CakeMethodAlias]
+        public static List<List<Group>> FindRegexMatchesGroupsInFile (this ICakeContext context, FilePath file, string rxFindPattern, RegexOptions rxOptions)
+        {
+            if (!context.FileSystem.Exist (file))
+                return null;
+
+            var rx = new Regex (rxFindPattern, rxOptions);
+            var contents = FileReadText (context, file);
+
+            var values = new List<List<Group>> ();
+
+            var matches = rx.Matches (contents);
+            foreach (Match m in matches)
+                if (m.Success)
+                    values.Add (m.Groups.Cast<Group> ().ToList ());
+
+            return values;
+        }
+
+        /// <summary>
+        /// Finds the first regex match in a file and returns all match groups.
+        /// </summary>
+        /// <returns>The match groups.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file.</param>
+        /// <param name="rxFindPattern">The regex pattern to search for.</param>
+        /// <param name="rxOptions">The regex options.</param>
+        [CakeMethodAlias]
+        public static List<Group> FindRegexMatchGroupsInFile (this ICakeContext context, FilePath file, string rxFindPattern, RegexOptions rxOptions)
+        {
+            var groups = FindRegexMatchesGroupsInFile (context, file, rxFindPattern, rxOptions);
+
+            return groups?.FirstOrDefault ();
+        }
+
+        /// <summary>
+        /// Finds the first regex match in a file and returns a specific match group.
+        /// </summary>
+        /// <returns>The matches with their groups.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file.</param>
+        /// <param name="rxFindPattern">The regex pattern to search for.</param>
+        /// <param name="groupIndex">The specific match group.</param>
+        /// <param name="rxOptions">The regex options.</param>
+        [CakeMethodAlias]
+        public static Group FindRegexMatchGroupInFile (this ICakeContext context, FilePath file, string rxFindPattern, int groupIndex, RegexOptions rxOptions)
+        {
+            var matchesGroups = FindRegexMatchesGroupsInFile (context, file, rxFindPattern, rxOptions);
+            var matchGroups = matchesGroups?.FirstOrDefault ();
+
+            if (matchGroups != null && matchGroups.Count > groupIndex)
+                return matchGroups[groupIndex];
+
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds 3 methods to find regex matches (or the first regex match) in a file which return `System.Text.RegularExpressionsGroup` objects instead of the match values:

```csharp
List<List<Group>> FindRegexMatchesGroupsInFile (FilePath file, string rxFindPattern, RegexOptions rxOptions)
List<Group> FindRegexMatchGroupsInFile (FilePath file, string rxFindPattern, RegexOptions rxOptions)
Group FindRegexMatchGroupInFile (FilePath file, string rxFindPattern, int groupIndex, RegexOptions rxOptions)
```