### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ xtc-email
 *.user
 
 #Cake
-[Tt]ools/
+tools/**
+!tools/packages.config
 BuildArtifacts/

--- a/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.29.0" />
-    <PackageReference Include="Cake.Testing" Version="0.29.0" />
+    <PackageReference Include="Cake.Core" Version="0.33.0" />
+    <PackageReference Include="Cake.Testing" Version="0.33.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.FileHelpers\Cake.FileHelpers.csproj" />

--- a/Cake.FileHelpers.Tests/Fakes/FakeCakeContext.cs
+++ b/Cake.FileHelpers.Tests/Fakes/FakeCakeContext.cs
@@ -16,7 +16,7 @@ namespace Cake.Xamarin.Tests.Fakes
         {
             testsDir = new DirectoryPath (
                 System.IO.Path.GetFullPath (AppContext.BaseDirectory));
-			
+
             var fileSystem = new FileSystem ();
             log = new FakeLog();
             var runtime = new CakeRuntime();
@@ -25,14 +25,15 @@ namespace Cake.Xamarin.Tests.Fakes
             var globber = new Globber (fileSystem, environment);
             
             var args = new FakeCakeArguments ();
-            var processRunner = new ProcessRunner (environment, log);
             var registry = new WindowsRegistry ();
             
             var dataService = new FakeDataService(); 
             var toolRepository = new ToolRepository(environment);
-            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, new FakeConfiguration());
+            var config = new FakeConfiguration();
+            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config);
             IToolLocator tools = new ToolLocator(environment, toolRepository, toolResolutionStrategy);
-            context = new CakeContext (fileSystem, environment, globber, log, args, processRunner, registry, tools, dataService);
+            var processRunner = new ProcessRunner(fileSystem, environment, log, tools, config);
+            context = new CakeContext (fileSystem, environment, globber, log, args, processRunner, registry, tools, dataService, config);
             context.Environment.WorkingDirectory = testsDir;
         }
 

--- a/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.29.0" />
-    <PackageReference Include="Cake.Common" Version="0.29.0" />
+    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Cake" version="0.32.1" />
+</packages>


### PR DESCRIPTION
Fixes #27. Example warning that would be fixed:
```
The assembly 'Cake.FileHelpers, Version=3.1.0.0, Culture=neutral, PublicKeyToken=null' 
is referencing an older version of Cake.Core (0.29.0). 
For best compatibility it should target Cake.Core version 0.33.0.
```