### PR TITLE
GH-33: Update Cake.FileHelpers to target Cake v1.0.0

### DIFF
--- a/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Testing" Version="0.33.0" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" />
+    <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />

--- a/Cake.FileHelpers.Tests/Fakes/FakeCakeArguments.cs
+++ b/Cake.FileHelpers.Tests/Fakes/FakeCakeArguments.cs
@@ -1,39 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cake.Core;
 
 namespace Cake.Xamarin.Tests.Fakes
 {
     internal sealed class FakeCakeArguments : ICakeArguments
     {
-        private readonly Dictionary<string, string> _arguments;
+        private readonly Dictionary<string, List<string>> _arguments;
 
         /// <summary>
         /// Gets the arguments.
         /// </summary>
         /// <value>The arguments.</value>
-        public IReadOnlyDictionary<string, string> Arguments
-        {
-            get { return _arguments; }
-        }
+        public IReadOnlyDictionary<string, List<string>> Arguments => _arguments;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CakeArguments"/> class.
         /// </summary>
         public FakeCakeArguments()
         {
-            _arguments = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _arguments = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
         /// Initializes the argument list.
         /// </summary>
         /// <param name="arguments">The arguments.</param>
-        public void SetArguments(IDictionary<string, string> arguments)
+        public void SetArguments(IDictionary<string, List<string>> arguments)
         {
             if (arguments == null)
             {
-                throw new ArgumentNullException("arguments");
+                throw new ArgumentNullException(nameof(arguments));
             }
             _arguments.Clear();
             foreach (var argument in arguments)
@@ -54,6 +52,12 @@ namespace Cake.Xamarin.Tests.Fakes
             return _arguments.ContainsKey(name);
         }
 
+        public ICollection<string> GetArguments(string name)
+        {
+            _arguments.TryGetValue(name, out var arguments);
+            return arguments ?? (ICollection<string>)Array.Empty<string>();
+        }
+
         /// <summary>
         /// Gets an argument.
         /// </summary>
@@ -61,8 +65,7 @@ namespace Cake.Xamarin.Tests.Fakes
         /// <returns>The argument value.</returns>
         public string GetArgument(string name)
         {
-            return _arguments.ContainsKey(name)
-                ? _arguments[name] : null;
+            return GetArguments(name).LastOrDefault();
         }
     }
 }

--- a/Cake.FileHelpers.Tests/Fakes/FakeCakeContext.cs
+++ b/Cake.FileHelpers.Tests/Fakes/FakeCakeContext.cs
@@ -21,7 +21,7 @@ namespace Cake.Xamarin.Tests.Fakes
             log = new FakeLog();
             var runtime = new CakeRuntime();
             var platform = new FakePlatform(PlatformFamily.Windows);
-            var environment = new CakeEnvironment (platform, runtime, log);
+            var environment = new CakeEnvironment(platform, runtime);
             var globber = new Globber (fileSystem, environment);
             
             var args = new FakeCakeArguments ();
@@ -30,7 +30,7 @@ namespace Cake.Xamarin.Tests.Fakes
             var dataService = new FakeDataService(); 
             var toolRepository = new ToolRepository(environment);
             var config = new FakeConfiguration();
-            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config);
+            var toolResolutionStrategy = new ToolResolutionStrategy(fileSystem, environment, globber, config, log);
             IToolLocator tools = new ToolLocator(environment, toolRepository, toolResolutionStrategy);
             var processRunner = new ProcessRunner(fileSystem, environment, log, tools, config);
             context = new CakeContext (fileSystem, environment, globber, log, args, processRunner, registry, tools, dataService, config);

--- a/Cake.FileHelpers.Tests/FileHelperTests.cs
+++ b/Cake.FileHelpers.Tests/FileHelperTests.cs
@@ -22,15 +22,15 @@ namespace Cake.FileHelpers.Tests
 
             d.Create();
         }
-        
-        public void Dispose ()
+
+        public void Dispose()
         {
-            context.DumpLogs ();
+            context.DumpLogs();
         }
 
         [Fact]
-        public void TestWriteAndReadText ()
-        {         
+        public void TestWriteAndReadText()
+        {
             const string file = "./testdata/Text.txt";
             const string contents = "This is a test";
 
@@ -42,8 +42,8 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
-        public void TestWriteAndReadLines ()
-        {   
+        public void TestWriteAndReadLines()
+        {
             const string file = "./testdata/Lines.txt";
             var contents = new [] { "This", "is", "a", "test" };
 
@@ -59,9 +59,9 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
-        public void FindTextInFilesGlob ()
+        public void FindTextInFilesGlob()
         {
-            SetupFiles ();
+            SetupFiles();
 
             var files = context.CakeContext.FindTextInFiles ("./testdata/*.txt", "Monkey");
 
@@ -70,7 +70,7 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
-        public void FindTextInFiles ()
+        public void FindTextInFiles()
         {
             SetupFiles();
 
@@ -83,9 +83,9 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
-        public void FindRegexInFiles ()
+        public void FindRegexInFiles()
         {
-            SetupFiles ();
+            SetupFiles();
 
             var files = context.CakeContext.FindRegexInFiles ("./testdata/*.txt", @"\s{1}Monkey\s{1,}");
 
@@ -95,9 +95,9 @@ namespace Cake.FileHelpers.Tests
 
 
         [Fact]
-        public void ReplaceTextInFiles ()
+        public void ReplaceTextInFiles()
         {
-            SetupFiles ();
+            SetupFiles();
 
             var files = context.CakeContext.ReplaceTextInFiles ("./testdata/*.txt", "Monkey", "Tamarin");
 
@@ -111,9 +111,9 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
-        public void ReplaceRegexInFiles ()
+        public void ReplaceRegexInFiles()
         {
-            SetupFiles ();
+            SetupFiles();
 
             var files = context.CakeContext.ReplaceRegexInFiles ("./testdata/*.txt", @"\s{1}Monkey\s{1,}", " Tamarin ");
 
@@ -131,7 +131,7 @@ namespace Cake.FileHelpers.Tests
         public const string GROUPS_PATTERN = "([A-Z])(\\w+)";
 
         [Fact]
-        public void FindRegexMatchesGroupsInFile ()
+        public void FindRegexMatchesGroupsInFile()
         {
             context.CakeContext.FileWriteText (GROUPS_FILE, GROUPS_FILE_CONTENT);
 
@@ -156,7 +156,7 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
-        public void FindRegexMatchGroupInFile ()
+        public void FindRegexMatchGroupInFile()
         {
             context.CakeContext.FileWriteText (GROUPS_FILE, GROUPS_FILE_CONTENT);
 
@@ -170,13 +170,13 @@ namespace Cake.FileHelpers.Tests
 
         public const string PATTERN_FILE_BASE_VALUE = "The {0} makes great software.\nThis is not a surprise.";
 
-        void SetupFiles ()
-        {            
+        void SetupFiles()
+        {
             // Setup files
             for (int i = 1; i < 5; i++) {
                 context.CakeContext.FileWriteText (
                     string.Format ("./testdata/{0}.txt", i),
-                    string.Format (PATTERN_FILE_BASE_VALUE, i == 2 ? "Monkey" : "Ape"));                
+                    string.Format (PATTERN_FILE_BASE_VALUE, i == 2 ? "Monkey" : "Ape"));
             }
         }
     }

--- a/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -31,7 +31,7 @@
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Update references to Cake.Core and Cake.Common to v1.0.0
- Update .NET Framework target to `net461` (was `net46`) (continues to multi-target `netstandard2.0` as before)
- Update unit tests to run on `netcoreapp3.1` (was `netcoreapp2.0` non-LTS)

---

Closes #33
