### PR TITLE
Update to Cake 2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,13 @@
 #---------------------------------#
 #  Build Image                    #
 #---------------------------------#
-image: Ubuntu
+image: Visual Studio 2022
 
 #---------------------------------#
 #  Build Script                   #
 #---------------------------------#
 build_script:
-  - sh: ./build.sh --target=CI
+  - ps: .\build.ps1 --target=CI
 
 #---------------------------------#
 # Tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,13 @@
 #---------------------------------#
 #  Build Image                    #
 #---------------------------------#
-image: Visual Studio 2019
+image: Ubuntu
 
 #---------------------------------#
 #  Build Script                   #
 #---------------------------------#
 build_script:
-  - ps: .\build.ps1 --target=CI
+  - sh: ./build.sh --target=CI
 
 #---------------------------------#
 # Tests

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "0.38.5",
       "commands": [
         "dotnet-cake"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.5",
+      "version": "2.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,12 @@ jobs:
         
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x' 
+        with:          
+          # gitversion needs 5.0 and we need all SDKs the project is targeting
+          dotnet-version: |
+            3.1.415
+            5.0.403
+            6.0.100
 
       - name: Cache Tools
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,11 @@ jobs:
 
       - name: Fetch all tags and branches
         run: git fetch --prune --unshallow
+        
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x' 
 
       - name: Cache Tools
         uses: actions/cache@v2

--- a/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -1,14 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Cake.Testing" Version="1.0.0"  />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net461' ">
+  <ItemGroup >
     <PackageReference Include="Cake.Testing" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Cake.Testing" Version="1.0.0"  />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net461' ">
     <PackageReference Include="Cake.Testing" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net50;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="Cake.Testing" Version="1.0.0"  />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
+    <PackageReference Include="Cake.Testing" Version="2.0.0" />
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" />
-    <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -19,8 +19,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.FileHelpers\Cake.FileHelpers.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/src/Cake.FileHelpers.Tests/Fakes/FakeCakeArguments.cs
+++ b/src/Cake.FileHelpers.Tests/Fakes/FakeCakeArguments.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Cake.Core;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Cake.Core;
 
 namespace Cake.Xamarin.Tests.Fakes
 {
@@ -52,10 +52,24 @@ namespace Cake.Xamarin.Tests.Fakes
             return _arguments.ContainsKey(name);
         }
 
+        /// <summary>
+        /// Gets all values for an argument.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public ICollection<string> GetArguments(string name)
         {
             _arguments.TryGetValue(name, out var arguments);
             return arguments ?? (ICollection<string>)Array.Empty<string>();
+        }
+
+        /// <summary>
+        ///  Gets all command line arguments.
+        /// </summary>
+        /// <returns></returns>
+        public IDictionary<string, ICollection<string>> GetArguments()
+        {
+            return _arguments as IDictionary<string, ICollection<string>>;
         }
 
         /// <summary>

--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -12,7 +12,7 @@
     <Title>Cake.FileHelpers</Title>
     <Summary>Cake build aliases for Reading, Writing, and Replacing Text in files.</Summary>
     <Description>Cake Build addon to provide Aliases for common File operations (Reading, Writing, Replacing Text).</Description>
-    <PackageTags>cake;script;build;cake-addin</PackageTags>
+    <PackageTags>cake;script;build;cake-addin;cake-build;addin</PackageTags>
     <Authors>Redth</Authors>
     <Owners>Redth; cake-contrib</Owners>
     <Copyright>Copyright 2017-$([System.DateTime]::Now.Year) - Cake Contributions</Copyright>
@@ -22,16 +22,16 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net461' ">
     <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CakeContrib.Guidelines" Version="1.2.0">
+    <PackageReference Include="CakeContrib.Guidelines" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net50;netstandard2.0;net46</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netstandard2.0;net46;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -22,12 +21,16 @@
     <RepositoryUrl>https://github.com/cake-contrib/Cake.FileHelpers.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net46' ">
+    <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="CakeContrib.Guidelines" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -22,15 +22,10 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net461' ">
+  <ItemGroup>
     <PackageReference Include="Cake.Common" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup>
+
     <PackageReference Include="CakeContrib.Guidelines" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Update to use Cake 2.0
- Support Cake 2.0 as well as .NET 6
- Update to use VS 2022 build image

Fixes #78, #77, #79, #76   