### PR TITLE
Use Cake's IFileSystem for read/write operations instead of System.IO.File

### DIFF
--- a/src/Cake.FileHelpers/FileHelpers.cs
+++ b/src/Cake.FileHelpers/FileHelpers.cs
@@ -732,7 +732,7 @@ namespace Cake.FileHelpers
 
         private static StreamReader CreateStreamReader(ICakeContext context, FilePath file, Encoding encoding = null)
         {
-            var stream = context.FileSystem.GetFile(file).OpenRead();
+            var stream = context.FileSystem.GetFile(file.MakeAbsolute(context.Environment)).OpenRead();
             return encoding is null
                 ? new StreamReader(stream, leaveOpen: false)
                 : new StreamReader(stream, encoding, leaveOpen: false);
@@ -740,7 +740,7 @@ namespace Cake.FileHelpers
 
         private static StreamWriter CreateStreamWriter(ICakeContext context, FilePath file, FileMode mode, Encoding encoding = null)
         {
-            var stream = context.FileSystem.GetFile(file).Open(mode);
+            var stream = context.FileSystem.GetFile(file.MakeAbsolute(context.Environment)).Open(mode);
             return encoding is null
                 ? new StreamWriter(stream, leaveOpen: false)
                 : new StreamWriter(stream, encoding, leaveOpen: false);

--- a/src/Cake.FileHelpers/FileHelpers.cs
+++ b/src/Cake.FileHelpers/FileHelpers.cs
@@ -730,8 +730,7 @@ namespace Cake.FileHelpers
             return null;
         }
 
-
-        private static StreamReader CreateStreamReader(ICakeContext context, FilePath file, Encoding? encoding = null)
+        private static StreamReader CreateStreamReader(ICakeContext context, FilePath file, Encoding encoding = null)
         {
             var stream = context.FileSystem.GetFile(file).OpenRead();
             return encoding is null
@@ -739,7 +738,7 @@ namespace Cake.FileHelpers
                 : new StreamReader(stream, encoding, leaveOpen: false);
         }
 
-        private static StreamWriter CreateStreamWriter(ICakeContext context, FilePath file, FileMode mode, Encoding? encoding = null)
+        private static StreamWriter CreateStreamWriter(ICakeContext context, FilePath file, FileMode mode, Encoding encoding = null)
         {
             var stream = context.FileSystem.GetFile(file).Open(mode);
             return encoding is null


### PR DESCRIPTION
## Description

In all file aliases, use Cake's IFileSystem abstraction instead of using System.IO.File. 
This enables testing of tasks that use the file aliases by mocking IFileSystem.

The FileTouch() alias continues to use System.IO.File since there is no API in IFileSystem that allows setting the last write time.

## Related Issue
This PR fixes #117

## Motivation and Context
See #117. This enables mocking of the file system in tests for tasks

## How Has This Been Tested?
All tests in the project are still passing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (*Covered by existing tests*)
- [x] All new and existing tests passed.
