### PR TITLE
Fix "Append" aliases

### DIFF
--- a/src/Cake.FileHelpers.Tests/FileHelperTests.cs
+++ b/src/Cake.FileHelpers.Tests/FileHelperTests.cs
@@ -60,6 +60,132 @@ namespace Cake.FileHelpers.Tests
         }
 
         [Fact]
+        public void TestAppendToNewFileAndReadText()
+        {
+            const string file = "./testdata/Text.txt";
+            const string contents = "This is a test";
+
+            context.CakeContext.FileAppendText(file, contents);
+
+            var read = context.CakeContext.FileReadText(file);
+
+            Assert.Equal(contents, read);
+        }
+
+        [Fact]
+        public void TestAppendToExistingFileAndReadText()
+        {
+            const string file = "./testdata/Text.txt";
+            const string contents1 = "This is ";
+            const string contents2 = "a test";
+
+            context.CakeContext.FileAppendText(file, contents1);
+            context.CakeContext.FileAppendText(file, contents2);
+
+            var read = context.CakeContext.FileReadText(file);
+
+            Assert.Equal(contents1 + contents2, read);
+        }
+
+        [Fact]
+        public void TestAppendToNewFileAndReadTextWithUTF8Encoding()
+        {
+            const string file = "./testdata/Text.txt";
+            const string contents = "Monkey🐒";
+
+            context.CakeContext.FileAppendText(file, Encoding.UTF8, contents);
+
+            var read = context.CakeContext.FileReadText(file, Encoding.UTF8);
+
+            Assert.Equal(contents, read);
+        }
+
+        [Fact]
+        public void TestAppendToExistingFileAndReadTextWithUTF8Encoding()
+        {
+            const string file = "./testdata/Text.txt";
+            const string contents1 = "Monkey";
+            const string contents2 = "🐒";
+
+            context.CakeContext.FileAppendText(file, Encoding.UTF8, contents1);
+            context.CakeContext.FileAppendText(file, Encoding.UTF8, contents2);
+
+            var read = context.CakeContext.FileReadText(file, Encoding.UTF8);
+
+            Assert.Equal(contents1 + contents2, read);
+        }
+
+        [Fact]
+        public void TestAppendLinesToNewFileAndReadLines()
+        {
+            const string file = "./testdata/Text.txt";
+            var contents = new[] { "This", "is", "a", "test" };
+
+            context.CakeContext.FileAppendLines(file, contents);
+
+            var read = context.CakeContext.FileReadLines(file);
+
+            Assert.Equal(contents.Length, read.Length);
+
+            for (int i = 0; i < read.Length; i++)
+                Assert.Equal(contents[i], read[i]);
+        }
+
+        [Fact]
+        public void TestAppendLinesToExistingFileAndReadLines()
+        {
+            const string file = "./testdata/Text.txt";
+            var contents = new[] { "This", "is", "a", "test" };
+            var contents1 = new[] { contents[0], contents[1] };
+            var contents2 = new[] { contents[2], contents[3] };
+
+            context.CakeContext.FileAppendLines(file, contents1);
+            context.CakeContext.FileAppendLines(file, contents2);
+
+            var read = context.CakeContext.FileReadLines(file);
+
+            Assert.Equal(contents.Length, read.Length);
+
+            for (int i = 0; i < read.Length; i++)
+                Assert.Equal(contents[i], read[i]);
+        }
+
+        [Fact]
+        public void TestAppendLinesToNewFileAndReadLinesWithUTF8Encoding()
+        {
+            const string file = "./testdata/Text.txt";
+            var contents = new[] { "This is a test", "Monkey🐒" };
+
+            context.CakeContext.FileAppendLines(file, Encoding.UTF8, contents);
+
+            var read = context.CakeContext.FileReadLines(file, Encoding.UTF8);
+
+            Assert.Equal(contents.Length, read.Length);
+
+            for (int i = 0; i < read.Length; i++)
+                Assert.Equal(contents[i], read[i]);
+        }
+
+        [Fact]
+        public void TestAppendLinesToExistingFileAndReadLinesWithUTF8Encoding()
+        {
+            const string file = "./testdata/Text.txt";
+            var contents = new[] { "This is a test", "Monkey🐒" };
+            var contents1 = new[] { contents[0] };
+            var contents2 = new[] { contents[1] };
+
+            context.CakeContext.FileAppendLines(file, Encoding.UTF8, contents1);
+            context.CakeContext.FileAppendLines(file, Encoding.UTF8, contents2);
+
+            var read = context.CakeContext.FileReadLines(file, Encoding.UTF8);
+
+            Assert.Equal(contents.Length, read.Length);
+
+            for (int i = 0; i < read.Length; i++)
+                Assert.Equal(contents[i], read[i]);
+        }
+
+        [Fact]
         public void FindTextInFilesGlob()
         {
             SetupFiles();

--- a/src/Cake.FileHelpers/FileHelpers.cs
+++ b/src/Cake.FileHelpers/FileHelpers.cs
@@ -135,7 +135,7 @@ namespace Cake.FileHelpers
         [CakeMethodAlias]
         public static void FileAppendText (this ICakeContext context, FilePath file, string text)
         {
-            using var streamWriter = CreateStreamWriter(context, file, FileMode.OpenOrCreate);
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Append);
             streamWriter.Write(text);
         }
 
@@ -149,7 +149,7 @@ namespace Cake.FileHelpers
         [CakeMethodAlias]
         public static void FileAppendText(this ICakeContext context, FilePath file, Encoding encoding, string text)
         {
-            using var streamWriter = CreateStreamWriter(context, file, FileMode.OpenOrCreate, encoding);
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Append, encoding);
             streamWriter.Write(text);
         }
 
@@ -162,7 +162,7 @@ namespace Cake.FileHelpers
         [CakeMethodAlias]
         public static void FileAppendLines (this ICakeContext context, FilePath file, string[] lines)
         {
-            using var streamWriter = CreateStreamWriter(context, file, FileMode.OpenOrCreate);
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Append);
             WriteLines(streamWriter, lines);
         }
 
@@ -176,7 +176,7 @@ namespace Cake.FileHelpers
         [CakeMethodAlias]
         public static void FileAppendLines(this ICakeContext context, FilePath file, Encoding encoding, string[] lines)
         {
-            using var streamWriter = CreateStreamWriter(context, file, FileMode.OpenOrCreate, encoding);
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Append, encoding);
             WriteLines(streamWriter, lines);
         }
 


### PR DESCRIPTION
## Description

In the "FileAppend" aliases (FileAppendText and FileAppendLines), open the file stream in file mode "Append" instead of "OpenOrCreate" so that the content is appended to the end of the file instead of (partially) overwriting the file from the beginning


## Related Issue
See #123 

## Motivation and Context
Fixes a bug (#123) introduced by #118

## How Has This Been Tested?

The PR adds additional unit tests for the `FileAppendText`/`FileAppendLines` aliases


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
