### PR TITLE
Update to Cake 5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,8 @@ jobs:
           # gitversion needs 5.0 and we need all SDKs the project is targeting
           dotnet-version: |
             5.0.403
-            6.0.100
-            7.0.100
             8.0.100
+            9.0.100
 
       - name: Cache Tools
         uses: actions/cache@v3

--- a/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Testing" Version="4.0.0" />

--- a/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Testing" Version="4.0.0" />
+    <PackageReference Include="Cake.Testing" Version="5.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -23,10 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="CakeContrib.Guidelines" Version="1.5.1">
+    <PackageReference Include="CakeContrib.Guidelines" Version="1.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
To update to Cake 5.0 target frameworks need to be net8 and net9.

## Related Issue
#153

## How Has This Been Tested?
Executed unit tests.

## Types of changes
- [x] Support Cake 5.0
- [x] Breaking Change: Removal of net6 and net7 target frameworks

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
