### PR TITLE
(#155) Cake v6.0.0 catch-up + IEnumerable<string> overloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,12 +84,13 @@ jobs:
           cake-version: tool-manifest
 
       # The demo/ folders exercise the just-built addin DLL under
-      # Cake-major-matching cake.tool / Cake.Frosting versions. They run
-      # in their OWN tool/package context (independent of recipe.cake's
-      # cake.tool, which is constrained by Cake.Recipe's runtime). Both
+      # Cake-major-matching cake.tool / Cake.Frosting / Cake.Sdk
+      # versions. They run in their OWN tool/package context
+      # (independent of recipe.cake's cake.tool, which is constrained
+      # by Cake.Recipe's runtime). demo/script and demo/frosting
       # consume the addin from BuildArtifacts/temp/_PublishedLibraries/
-      # populated by DotNetCore-Pack. demo/sdk joins at the Cake 6
-      # catch-up release.
+      # populated by DotNetCore-Pack; demo/sdk builds the addin from
+      # source via the #:project directive in cake.cs.
 
       - name: Run demo/script
         if: success()
@@ -100,6 +101,12 @@ jobs:
         if: success()
         shell: pwsh
         run: ./demo/frosting/build.ps1
+
+      - name: Run demo/sdk
+        if: success()
+        shell: pwsh
+        working-directory: ./demo/sdk
+        run: dotnet cake.cs
 
       - name: Upload Issues-Report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -9,6 +9,6 @@
     <Reference Include="Cake.FileHelpers">
       <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.FileHelpers\net8.0\Cake.FileHelpers.dll</HintPath>
     </Reference>
-    <PackageReference Include="Cake.Frosting" Version="5.1.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
         "cake.tool": {
-            "version": "5.1.0",
+            "version": "6.1.0",
             "commands": [
                 "dotnet-cake"
             ]

--- a/demo/sdk/cake.cs
+++ b/demo/sdk/cake.cs
@@ -1,0 +1,195 @@
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk@6.1.1
+#:project ../../src/Cake.FileHelpers/Cake.FileHelpers.csproj
+
+// Cake SDK consumer demo for Cake.FileHelpers. Runs as a file-based
+// .NET program (introduced in .NET 10) using the Cake.Sdk
+// directives. The #:project directive above lets the SDK build the
+// addin from source rather than referencing a published nupkg.
+//
+// To run locally:
+//   cd demo/sdk
+//   dotnet cake.cs
+//
+// Mirrors the alias surface exercised by demo/script/filehelpers.cake
+// and demo/frosting/, against a temp working directory under
+// demo/sdk/BuildArtifacts/ (gitignored). Each task asserts the
+// expected outcome and throws on mismatch — the script fails
+// (non-zero exit) if any alias misbehaves.
+
+using Cake.FileHelpers;
+
+var workDir = Directory("./BuildArtifacts/temp/test-filehelpers-sdk");
+var sampleFile = workDir + File("sample.txt");
+var sampleFile2 = workDir + File("sample2.txt");
+
+Task("Default")
+    .IsDependentOn("Setup")
+    .IsDependentOn("Read-Operations")
+    .IsDependentOn("Write-Operations")
+    .IsDependentOn("Append-Operations")
+    .IsDependentOn("Touch")
+    .IsDependentOn("Find-Operations")
+    .IsDependentOn("Replace-Operations")
+    .IsDependentOn("Cleanup");
+
+Task("Setup")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    EnsureDirectoryExists(workDir);
+    System.IO.File.WriteAllLines(
+        sampleFile.Path.FullPath,
+        new[] { "alpha line 1", "beta line 2", "gamma 42 delta", "alpha line 4" });
+    System.IO.File.WriteAllText(sampleFile2.Path.FullPath, "second file with the word alpha");
+    Information("Setup complete.");
+});
+
+Task("Read-Operations")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var lines = FileReadLines(sampleFile);
+    AssertThat(lines.Length == 4, "FileReadLines: expected 4 lines, got " + lines.Length);
+    AssertThat(lines[0] == "alpha line 1", "FileReadLines: first line mismatch");
+    AssertThat(lines[3] == "alpha line 4", "FileReadLines: last line mismatch");
+    Information("FileReadLines OK ({0} lines)", lines.Length);
+
+    var text = FileReadText(sampleFile);
+    AssertThat(text.Contains("gamma 42 delta"), "FileReadText: expected content not found");
+    Information("FileReadText OK ({0} chars)", text.Length);
+});
+
+Task("Write-Operations")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var writeFile = workDir + File("written.txt");
+
+    FileWriteText(writeFile, "first text\n");
+    var afterText = System.IO.File.ReadAllText(writeFile.Path.FullPath);
+    AssertThat(afterText == "first text\n", "FileWriteText: content mismatch");
+    Information("FileWriteText OK");
+
+    FileWriteLines(writeFile, new[] { "line A", "line B", "line C" });
+    var afterLines = FileReadLines(writeFile);
+    AssertThat(afterLines.Length == 3, "FileWriteLines: expected 3 lines, got " + afterLines.Length);
+    AssertThat(afterLines[1] == "line B", "FileWriteLines: line 2 mismatch");
+    Information("FileWriteLines OK (overwrote with {0} lines)", afterLines.Length);
+});
+
+Task("Append-Operations")
+    .IsDependentOn("Write-Operations")
+    .Does(() =>
+{
+    var writeFile = workDir + File("written.txt");
+    var beforeLines = FileReadLines(writeFile);
+
+    FileAppendText(writeFile, "appended text\n");
+    FileAppendLines(writeFile, new[] { "appended line 1", "appended line 2" });
+    var afterLines = FileReadLines(writeFile);
+
+    AssertThat(afterLines.Length == beforeLines.Length + 3,
+        $"Append: expected {beforeLines.Length + 3} lines, got {afterLines.Length}");
+    AssertThat(afterLines[afterLines.Length - 1] == "appended line 2",
+        "Append: last line mismatch");
+    Information("FileAppendText + FileAppendLines OK ({0} lines after append)", afterLines.Length);
+});
+
+Task("Touch")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var touchFile = workDir + File("touched.txt");
+    System.IO.File.WriteAllText(touchFile.Path.FullPath, string.Empty);
+    var beforeUtc = System.IO.File.GetLastWriteTimeUtc(touchFile.Path.FullPath);
+    System.Threading.Thread.Sleep(10);
+    FileTouch(touchFile);
+    var afterUtc = System.IO.File.GetLastWriteTimeUtc(touchFile.Path.FullPath);
+
+    AssertThat(afterUtc > beforeUtc,
+        $"FileTouch: timestamp did not advance (before={beforeUtc:o}, after={afterUtc:o})");
+    Information("FileTouch OK (advanced from {0:o} to {1:o})", beforeUtc, afterUtc);
+});
+
+Task("Find-Operations")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var byText = FindTextInFiles(workDir + File("sample*.txt"), "alpha");
+    AssertThat(byText.Length == 2, "FindTextInFiles 'alpha': expected 2 files, got " + byText.Length);
+    Information("FindTextInFiles 'alpha' OK ({0} files)", byText.Length);
+
+    var byRegex = FindRegexInFiles(workDir + File("sample*.txt"), @"\d+");
+    AssertThat(byRegex.Length == 1, "FindRegexInFiles digits: expected 1 file (sample.txt has '42'), got " + byRegex.Length);
+    Information("FindRegexInFiles digits OK ({0} file)", byRegex.Length);
+
+    var single = FindRegexMatchInFile(sampleFile, @"\d+", System.Text.RegularExpressions.RegexOptions.None);
+    AssertThat(single == "1", "FindRegexMatchInFile: expected first digit run '1' (from 'line 1'), got " + (single ?? "null"));
+    Information("FindRegexMatchInFile digits OK ('{0}')", single);
+
+    var many = FindRegexMatchesInFile(sampleFile, @"alpha", System.Text.RegularExpressions.RegexOptions.None);
+    AssertThat(many != null && many.Count == 2, $"FindRegexMatchesInFile 'alpha': expected 2 matches, got {many?.Count ?? 0}");
+    Information("FindRegexMatchesInFile 'alpha' OK ({0} matches)", many.Count);
+
+    var group = FindRegexMatchGroupInFile(sampleFile, @"gamma (\d+)", 1, System.Text.RegularExpressions.RegexOptions.None);
+    AssertThat(group != null && group.Value == "42", "FindRegexMatchGroupInFile: expected group '42', got " + (group?.Value ?? "null"));
+    Information("FindRegexMatchGroupInFile OK ('{0}')", group.Value);
+
+    var groups = FindRegexMatchGroupsInFile(sampleFile, @"(alpha) (line)", System.Text.RegularExpressions.RegexOptions.None);
+    AssertThat(groups != null && groups.Count == 3, $"FindRegexMatchGroupsInFile: expected 3 groups (full + 2 captures), got {groups?.Count ?? 0}");
+    Information("FindRegexMatchGroupsInFile OK ({0} groups)", groups.Count);
+
+    var allGroups = FindRegexMatchesGroupsInFile(sampleFile, @"(alpha) (line)", System.Text.RegularExpressions.RegexOptions.None);
+    AssertThat(allGroups != null && allGroups.Count == 2, $"FindRegexMatchesGroupsInFile: expected 2 matches, got {allGroups?.Count ?? 0}");
+    Information("FindRegexMatchesGroupsInFile OK ({0} matches)", allGroups.Count);
+});
+
+Task("Replace-Operations")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var changed = ReplaceTextInFiles(workDir + File("sample*.txt"), "alpha", "ALPHA");
+    AssertThat(changed.Length == 2, "ReplaceTextInFiles 'alpha'->'ALPHA': expected 2 changed files, got " + changed.Length);
+
+    var afterText = FileReadText(sampleFile);
+    AssertThat(afterText.Contains("ALPHA") && !afterText.Contains("alpha"), "ReplaceTextInFiles: replacement not applied to sample.txt");
+    Information("ReplaceTextInFiles OK ({0} files modified)", changed.Length);
+
+    var changedRx = ReplaceRegexInFiles(workDir + File("sample*.txt"), @"beta", "BETA");
+    AssertThat(changedRx.Length == 1, "ReplaceRegexInFiles 'beta'->'BETA': expected 1 changed file (only sample.txt has 'beta'), got " + changedRx.Length);
+    var afterRegex = FileReadText(sampleFile);
+    AssertThat(afterRegex.Contains("BETA"), "ReplaceRegexInFiles: replacement not applied");
+    Information("ReplaceRegexInFiles OK ({0} files modified)", changedRx.Length);
+});
+
+Task("Cleanup")
+    .IsDependentOn("Replace-Operations")
+    .IsDependentOn("Append-Operations")
+    .IsDependentOn("Touch")
+    .IsDependentOn("Find-Operations")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    Information("Cleanup complete.");
+});
+
+RunTarget("Default");
+
+// ----- Helpers (must come AFTER top-level statements per CS8803) -----
+
+static void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.100",
+      "version": "10.0.100",
       "rollForward": "latestFeature"
     }
   }

--- a/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
+++ b/src/Cake.FileHelpers.Tests/Cake.FileHelpers.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.FileHelpers.Tests/FileHelperTests.cs
+++ b/src/Cake.FileHelpers.Tests/FileHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Cake.Xamarin.Tests.Fakes;
 using Cake.Core.IO;
@@ -183,6 +184,64 @@ namespace Cake.FileHelpers.Tests
 
             for (int i = 0; i < read.Length; i++)
                 Assert.Equal(contents[i], read[i]);
+        }
+
+        [Fact]
+        public void TestWriteLinesAcceptsIEnumerable()
+        {
+            const string file = "./testdata/Lines.txt";
+            IEnumerable<string> contents = new List<string> { "This", "is", "a", "test" };
+
+            context.CakeContext.FileWriteLines(file, contents);
+
+            var read = context.CakeContext.FileReadLines(file);
+
+            Assert.Equal(4, read.Length);
+            Assert.Equal("This", read[0]);
+            Assert.Equal("test", read[3]);
+        }
+
+        [Fact]
+        public void TestWriteLinesAcceptsIEnumerableWithUTF8Encoding()
+        {
+            const string file = "./testdata/Lines.txt";
+            IEnumerable<string> contents = new List<string> { "This is a test", "Monkey🐒" };
+
+            context.CakeContext.FileWriteLines(file, Encoding.UTF8, contents);
+
+            var read = context.CakeContext.FileReadLines(file, Encoding.UTF8);
+
+            Assert.Equal(2, read.Length);
+            Assert.Equal("Monkey🐒", read[1]);
+        }
+
+        [Fact]
+        public void TestAppendLinesAcceptsIEnumerable()
+        {
+            const string file = "./testdata/Text.txt";
+            IEnumerable<string> contents = new List<string> { "This", "is", "a", "test" };
+
+            context.CakeContext.FileAppendLines(file, contents);
+
+            var read = context.CakeContext.FileReadLines(file);
+
+            Assert.Equal(4, read.Length);
+            Assert.Equal("This", read[0]);
+            Assert.Equal("test", read[3]);
+        }
+
+        [Fact]
+        public void TestAppendLinesAcceptsIEnumerableWithUTF8Encoding()
+        {
+            const string file = "./testdata/Text.txt";
+            IEnumerable<string> contents = new List<string> { "This is a test", "Monkey🐒" };
+
+            context.CakeContext.FileAppendLines(file, Encoding.UTF8, contents);
+
+            var read = context.CakeContext.FileReadLines(file, Encoding.UTF8);
+
+            Assert.Equal(2, read.Length);
+            Assert.Equal("Monkey🐒", read[1]);
         }
 
         [Fact]

--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
 
     <PackageReference Include="CakeContrib.Guidelines" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.FileHelpers/FileHelpers.cs
+++ b/src/Cake.FileHelpers/FileHelpers.cs
@@ -127,6 +127,33 @@ namespace Cake.FileHelpers
         }
 
         /// <summary>
+        /// Writes all text lines to a file
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file to write to.</param>
+        /// <param name="lines">The text lines to write.</param>
+        [CakeMethodAlias]
+        public static void FileWriteLines(this ICakeContext context, FilePath file, IEnumerable<string> lines)
+        {
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Create);
+            WriteLines(streamWriter, lines);
+        }
+
+        /// <summary>
+        /// Writes all text lines to a file
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file to write to.</param>
+        /// <param name="encoding">The encoding to use for the file.</param>
+        /// <param name="lines">The text lines to write.</param>
+        [CakeMethodAlias]
+        public static void FileWriteLines(this ICakeContext context, FilePath file, Encoding encoding, IEnumerable<string> lines)
+        {
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Create, encoding);
+            WriteLines(streamWriter, lines);
+        }
+
+        /// <summary>
         /// Appends all text to a file
         /// </summary>
         /// <param name="context">The context.</param>
@@ -175,6 +202,33 @@ namespace Cake.FileHelpers
         /// <param name="lines">The text lines to append.</param>
         [CakeMethodAlias]
         public static void FileAppendLines(this ICakeContext context, FilePath file, Encoding encoding, string[] lines)
+        {
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Append, encoding);
+            WriteLines(streamWriter, lines);
+        }
+
+        /// <summary>
+        /// Appends all text lines to a file
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file to append text to.</param>
+        /// <param name="lines">The text lines to append.</param>
+        [CakeMethodAlias]
+        public static void FileAppendLines(this ICakeContext context, FilePath file, IEnumerable<string> lines)
+        {
+            using var streamWriter = CreateStreamWriter(context, file, FileMode.Append);
+            WriteLines(streamWriter, lines);
+        }
+
+        /// <summary>
+        /// Appends all text lines to a file
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file to append text to.</param>
+        /// <param name="encoding">The encoding to use for the file.</param>
+        /// <param name="lines">The text lines to append.</param>
+        [CakeMethodAlias]
+        public static void FileAppendLines(this ICakeContext context, FilePath file, Encoding encoding, IEnumerable<string> lines)
         {
             using var streamWriter = CreateStreamWriter(context, file, FileMode.Append, encoding);
             WriteLines(streamWriter, lines);
@@ -759,7 +813,7 @@ namespace Cake.FileHelpers
             return lines.ToArray();
         }
 
-        private static void WriteLines(StreamWriter streamWriter, string[] lines) 
+        private static void WriteLines(StreamWriter streamWriter, IEnumerable<string> lines)
         { 
             foreach (var line in lines)
             {


### PR DESCRIPTION
Closes #155.
Closes #2.

## Scope

### Cake 6 catch-up (#155)

- **Addin**: `Cake.Core` / `Cake.Common` `5.0.0 → 6.0.0`. TFMs gain `net10.0` (now `net8.0;net9.0;net10.0`).
- **Tests**: `Cake.Testing` `5.0.0 → 6.0.0`. Tests TFM stays at `net8.0` (lowest-of-addin's-range, per the workspace rotation table for Cake 6.x).
- **`global.json`**: SDK `9.0.100 → 10.0.100`, matching the new highest TFM.
- **`demo/script/.config/dotnet-tools.json`**: cake.tool `5.1.0 → 6.1.0` (latest 6.x as of 2026-05-07).
- **`demo/frosting/build/Build.csproj`**: `Cake.Frosting` `5.1.0 → 6.1.0`. HintPath stays at `net8.0`.
- **`demo/sdk/cake.cs` (NEW)**: `Cake.Sdk@6.1.1` file-based program with `#:project ../../src/Cake.FileHelpers/Cake.FileHelpers.csproj`. Mirrors the alias surface exercised by `demo/script` and `demo/frosting`. No `Nullable=enable` / `NoWarn=CS8603` properties needed — Cake.FileHelpers' public API doesn't use nullable annotations, so the source-generator nullability gap (workspace memory `feedback_demo_folder_pattern`) isn't triggered.
- **`build.yml`**: new `Run demo/sdk` step after `Run demo/frosting`, using `working-directory: ./demo/sdk` and `dotnet cake.cs`.

### `IEnumerable<string>` overloads (#2)

10-year-old request — fold in as a free modernisation since v9.0.0 is a Breaking-change release boundary anyway. Four new public overloads on `FileHelperAliases`:

- `FileWriteLines(this ICakeContext, FilePath, IEnumerable<string>)`
- `FileWriteLines(this ICakeContext, FilePath, Encoding, IEnumerable<string>)`
- `FileAppendLines(this ICakeContext, FilePath, IEnumerable<string>)`
- `FileAppendLines(this ICakeContext, FilePath, Encoding, IEnumerable<string>)`

Existing `string[]` overloads stay (binary-compat for downstream addins linking via `PackageReference`); overload resolution picks the existing `string[]` form when a literal `new[] { ... }` is passed, so no behaviour change at any current call site. The internal `WriteLines` helper widens to `IEnumerable<string>` — `string[]` satisfies that contract, so all existing call sites keep working unchanged.

Tests added covering each new overload via `List<string>` typed as `IEnumerable<string>` (guarantees the new overload is dispatched rather than the `string[]` one).

## Out of scope

- No `ArgumentNullException.ThrowIfNull` modernisation — Cake.FileHelpers' source has no explicit null-checked code paths (the addin defers null handling to the underlying `System.IO` calls), so there's nothing to modernise.
- Long-stale feature requests #5 / #6 / #24 — each needs an API-shape decision before implementation. Tracked as a single triage follow-up in the workspace TODO.
- Renovate PRs and the addin-side `IDisposableAnalyzers` / `Microsoft.SourceLink.GitHub` analyzer pins — those track .NET / source-link versions, not Cake major, and Renovate drives them.

## Local verification

- `dotnet cake recipe.cake --target=Package` — green (`DotNetCore-Test` + `DotNetCore-Pack` both pass).
- `dotnet test --filter "FullyQualifiedName~AcceptsIEnumerable"` — 4/4 pass for the new overload tests.
- `./demo/script/build.ps1` — all 8 tasks succeeded under cake.tool 6.1.0.
- `./demo/frosting/build.ps1` — all 8 tasks succeeded under Cake.Frosting 6.1.0.
- `dotnet cake.cs` (in `demo/sdk/`) — all 8 tasks succeeded under Cake.Sdk 6.1.1 + .NET 10 SDK 10.0.107.

## Release context

- #155 (`Breaking change`) — the `Cake.Core` 5.0.0 → 6.0.0 bump.
- #2 (`Feature`) — the `IEnumerable<string>` overloads.

Both are attached to milestone 9.0.0; this PR closes both via `Closes #155` / `Closes #2`.