### PR TITLE
(maint) Drop vestigial CakeContribGuidelinesOmitTargetFramework configs

### DIFF
--- a/src/Cake.FileHelpers/Cake.FileHelpers.csproj
+++ b/src/Cake.FileHelpers/Cake.FileHelpers.csproj
@@ -47,7 +47,5 @@
   <ItemGroup>
     <CakeContribGuidelinesOmitRecommendedReference Include="StyleCop.Analyzers" />
     <CakeContribGuidelinesOmitRecommendedConfigFile Include="stylecop.json" />
-    <CakeContribGuidelinesOmitTargetFramework Include="net6.0" />
-    <CakeContribGuidelinesOmitTargetFramework Include="net7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Cleanup spotted while reviewing the Cake.Incubator v11.0.0 catch-up
([cake-contrib/Cake.Incubator#269](https://github.com/cake-contrib/Cake.Incubator/pull/269))
— the same two `<CakeContribGuidelinesOmitTargetFramework>` lines for
`net6.0` and `net7.0` had been copied here by analogy without anyone
empirically verifying they were still needed.

### Empirical check

Built with all four omit lines, then with only the two StyleCop omits,
then with none. Result:

| Lines kept | Warnings emitted (excluding pre-existing CS0618 / CS1591 / NU1510) |
|---|---|
| All four (current) | none |
| Only `OmitRecommendedReference="StyleCop.Analyzers"` + `OmitRecommendedConfigFile="stylecop.json"` | none |
| None | `CCG0005` × 3 (StyleCop.Analyzers reference missing, once per TFM) + `CCG0006` × 3 (stylecop.json missing) |

The StyleCop pair silences real warnings (Cake.FileHelpers doesn't
use StyleCop, unlike Cake.Coveralls / Cake.ReSharperReports which
both list `StyleCop.Analyzers` as a real PackageReference). The
`net6.0` / `net7.0` pair fires zero warnings under CakeContrib.Guidelines
1.7.0 — that analyzer was updated to stop asking for those TFMs once
they hit EOL, so the omit lines became copy-from-older-CCG-state noise.

### Out of scope

- No source code touched, no behaviour change.
- StyleCop omit pair stays.
- No new release needed — this is csproj hygiene; ships in whatever
  the next FileHelpers release happens to be.